### PR TITLE
Create basic application entry point with Iced GUI - Issue #4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,6 +3146,7 @@ version = "0.1.0"
 dependencies = [
  "background-service",
  "gui",
+ "iced",
  "likeminded-core",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,4 @@ background-service = { path = "background-service" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+iced = { workspace = true }

--- a/gui/src/lib.rs
+++ b/gui/src/lib.rs
@@ -1,3 +1,5 @@
+use iced::widget::{button, column, container, text, Column};
+use iced::{Element, Length, Theme};
 use likeminded_core::{CoreError, RedditPost};
 
 #[derive(Debug, Clone)]
@@ -23,10 +25,10 @@ impl App {
 
     pub fn update(&mut self, message: Message) -> Result<(), CoreError> {
         match message {
-            Message::PostClicked(post_id) => {
+            Message::PostClicked(_post_id) => {
                 todo!("Handle post click - open in browser")
             }
-            Message::MarkAsRead(post_id) => {
+            Message::MarkAsRead(_post_id) => {
                 todo!("Handle mark as read")
             }
             Message::FilterBySubreddit(subreddit) => {
@@ -39,7 +41,43 @@ impl App {
         }
     }
 
-    pub fn view(&self) -> String {
-        todo!("Implement Iced view")
+    pub fn view(&self) -> Element<Message, Theme> {
+        let title: Element<Message, Theme> =
+            text("Likeminded - Reddit Post Filter").size(24).into();
+
+        let content: Element<Message, Theme> = if self.posts.is_empty() {
+            column![
+                text("No posts available").size(16),
+                text("Connect to Reddit to start filtering posts").size(14)
+            ]
+            .spacing(10)
+            .into()
+        } else {
+            let mut post_list = Column::new().spacing(10);
+            for post in &self.posts {
+                let post_element: Element<Message, Theme> = container(
+                    column![
+                        text(&post.title).size(16),
+                        text(format!("r/{}", post.subreddit)).size(12),
+                        button("Mark as Read").on_press(Message::MarkAsRead(post.id.clone()))
+                    ]
+                    .spacing(5),
+                )
+                .padding(10)
+                .into();
+                post_list = post_list.push(post_element);
+            }
+            post_list.into()
+        };
+
+        let main_content: Element<Message, Theme> = column![title, container(content).padding(20)]
+            .spacing(20)
+            .into();
+
+        container(main_content)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(20)
+            .into()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,57 @@
+use gui::App;
+use iced::{Application, Settings};
 use likeminded_core::CoreError;
 
 #[tokio::main]
 async fn main() -> Result<(), CoreError> {
-    println!("Likeminded - Reddit Post Filter");
+    tracing_subscriber::fmt()
+        .with_env_filter("likeminded=debug,gui=debug")
+        .init();
 
-    Ok(())
+    tracing::info!("Starting Likeminded - Reddit Post Filter");
+
+    let settings = Settings {
+        window: iced::window::Settings {
+            size: iced::Size::new(1200.0, 800.0),
+            min_size: Some(iced::Size::new(800.0, 600.0)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    LikemindedApp::run(settings).map_err(|e| {
+        tracing::error!("Application error: {}", e);
+        CoreError::Configuration(format!("GUI error: {e}"))
+    })
+}
+
+struct LikemindedApp {
+    app: App,
+}
+
+impl Application for LikemindedApp {
+    type Message = gui::Message;
+    type Theme = iced::Theme;
+    type Executor = iced::executor::Default;
+    type Flags = ();
+
+    fn new(_flags: Self::Flags) -> (Self, iced::Command<Self::Message>) {
+        tracing::info!("Initializing application");
+        (Self { app: App::new() }, iced::Command::none())
+    }
+
+    fn title(&self) -> String {
+        "Likeminded - Reddit Post Filter".to_string()
+    }
+
+    fn update(&mut self, message: Self::Message) -> iced::Command<Self::Message> {
+        if let Err(e) = self.app.update(message) {
+            tracing::error!("Update error: {}", e);
+        }
+        iced::Command::none()
+    }
+
+    fn view(&self) -> iced::Element<Self::Message> {
+        self.app.view()
+    }
 }


### PR DESCRIPTION
- Implement main.rs with Iced Application trait
- Set up basic window configuration (1200x800, min 800x600)
- Add application state management with LikemindedApp wrapper
- Create placeholder GUI layout with title and empty state
- Configure logging with tracing subscriber
- Add proper error handling and application lifecycle

🤖 Generated with [Claude Code](https://claude.ai/code)